### PR TITLE
WIP: Upate podman collection to latest version

### DIFF
--- a/galaxy-requirements.yaml
+++ b/galaxy-requirements.yaml
@@ -2,3 +2,6 @@ roles:
   - name: monolithprojects.github_actions_runner
     version: 1.21.1
     src: https://github.com/MonolithProjects/ansible-github_actions_runner
+collections:
+  - name: containers.podman
+    version: 1.16.3


### PR DESCRIPTION
Upgrading containers.podman to a version that supports quadlets.

This update installs containers.podman 1.16.3 in /root/.ansible/collections/ansible_collections.  This is done in addition of existing containers.podman 1.10.3

As a result of rebuild other minor version updates occur:

```
< amazon.aws                    6.5.0  
< ansible.netcommon             5.2.0  
---
> amazon.aws                    6.2.0  
> ansible.netcommon             5.1.2  
13c8
< ansible.utils                 2.11.0 
---
> ansible.utils                 2.10.3 
15,17c10,12
< arista.eos                    6.1.2  
< awx.awx                       22.7.0 
< azure.azcollection            1.18.1 
---
> arista.eos                    6.0.1  
> awx.awx                       22.5.0 
> azure.azcollection            1.16.0 
20,22c15,17
< cisco.aci                     2.7.0  
< cisco.asa                     4.0.2  
< cisco.dnac                    6.7.5  
---
> cisco.aci                     2.6.0  
> cisco.asa                     4.0.1  
> cisco.dnac                    6.7.3  
26,28c21,23
< cisco.ise                     2.5.16 
< cisco.meraki                  2.16.5 
< cisco.mso                     2.5.0  
---
> cisco.ise                     2.5.12 
> cisco.meraki                  2.15.3 
> cisco.mso                     2.4.0  
31,32c26,27
< cisco.ucs                     1.10.0 
< cloud.common                  2.1.4  
---
> cisco.ucs                     1.9.0  
> cloud.common                  2.1.3  
34c29
< community.aws                 6.3.0  
---
> community.aws                 6.1.0  
37,40c32,35
< community.crypto              2.15.1 
< community.digitalocean        1.24.0 
< community.dns                 2.6.2  
< community.docker              3.4.9  
---
> community.crypto              2.14.1 
> community.digitalocean        1.23.0 
> community.dns                 2.5.7  
> community.docker              3.4.8  
42c37
< community.general             7.5.0  
---
> community.general             7.2.0  
47,48c42,43
< community.libvirt             1.3.0  
< community.mongodb             1.6.3  
---
> community.libvirt             1.2.0  
> community.mongodb             1.6.1  
52c47
< community.postgresql          2.4.3  
---
> community.postgresql          2.4.2  
55c50
< community.routeros            2.10.0 
---
> community.routeros            2.8.3  
59,60c54,55
< community.sops                1.6.6  
< community.vmware              3.10.0 
---
> community.sops                1.6.4  
> community.vmware              3.8.0  
63,65c58,60
< containers.podman             1.10.3 
< cyberark.conjur               1.2.2  
< cyberark.pas                  1.0.23 
---
> containers.podman             1.10.2 
> cyberark.conjur               1.2.0  
> cyberark.pas                  1.0.19 
68,72c63,67
< dellemc.powerflex             1.9.0  
< dellemc.unity                 1.7.1  
< f5networks.f5_modules         1.26.0 
< fortinet.fortimanager         2.2.1  
< fortinet.fortios              2.3.2  
---
> dellemc.powerflex             1.7.0  
> dellemc.unity                 1.7.0  
> f5networks.f5_modules         1.25.0 
> fortinet.fortimanager         2.2.0  
> fortinet.fortios              2.3.0  
76c71
< grafana.grafana               2.2.3  
---
> grafana.grafana               2.1.4  
85c80
< junipernetworks.junos         5.3.0  
---
> junipernetworks.junos         5.2.0  
87,88c82,83
< lowlydba.sqlserver            2.2.1  
< microsoft.ad                  1.3.0  
---
> lowlydba.sqlserver            2.0.0  
> microsoft.ad                  1.2.0  
97c92
< netbox.netbox                 3.14.0 
---
> netbox.netbox                 3.13.0 
99c94
< ngine_io.exoscale             1.1.0  
---
> ngine_io.exoscale             1.0.0  
103,107c98,102
< ovirt.ovirt                   3.2.0  
< purestorage.flasharray        1.21.0 
< purestorage.flashblade        1.14.0 
< purestorage.fusion            1.6.0  
< sensu.sensu_go                1.14.0 
---
> ovirt.ovirt                   3.1.2  
> purestorage.flasharray        1.20.0 
> purestorage.flashblade        1.12.1 
> purestorage.fusion            1.5.0  
> sensu.sensu_go                1.13.2 
111,112c106
< telekom_mms.icinga_director   1.34.1 
< theforeman.foreman            3.14.0 
---
> theforeman.foreman            3.12.0 
114c108
< vultr.cloud                   1.10.0 
---
> vultr.cloud                   1.8.0 
```