### PR TITLE
Conatiner image name fix

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -12,5 +12,5 @@ jobs:
     uses: nerc-project/nerc-github-workflows/.github/workflows/build-image.yaml@main
 
     with:
-      image: nerc-ansible-container
+      image: ghcr.io/nerc-project/nerc-ansible-container
     secrets: inherit


### PR DESCRIPTION
Changes in previous pr commit container name defaulted to docker hub path instead of github repo.
Based on action output:
https://github.com/nerc-project/nerc-ansible-container/actions/runs/17447316340/job/49544844650#step:5:1304

I'm hoping that setting full path name will fix it.